### PR TITLE
Use doc.parentWindow if no doc.defaultView

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,5 +40,5 @@ function getWindow(node) {
 
   // TODO: add old-IE fallback logic: http://stackoverflow.com/a/10260692
   var doc = getDocument(node);
-  return doc.defaultView;
+  return doc.defaultView || doc.parentWindow;
 }


### PR DESCRIPTION
This seems to work with IE8 and I would just guess that IE7, as well.
